### PR TITLE
Feature: Add a dropdown to disable google consent mode from admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.0.8] - 2022-08-03
 
 ### Added
 - Admin setting that allow to disable Google Consent Mode following [Cookiebot indications](https://support.cookiebot.com/hc/en-us/articles/4417367208594-Disabling-Google-Consent-mode) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.8] - 2022-08-03
+
+### Added
+- Admin setting that allow to disable Google Consent Mode following [Cookiebot indications](https://support.cookiebot.com/hc/en-us/articles/4417367208594-Disabling-Google-Consent-mode) 
+
 ## [2.0.7] - 2021-09-28
 
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
-  "vendor": "vtex",
-  "version": "2.0.7",
+  "vendor": "arcaplanetqa",
+  "version": "0.0.0",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {
@@ -31,6 +31,10 @@
     "properties": {
       "cbid": {
         "title": "Domain Group ID",
+        "type": "string"
+      },
+      "gcm": {
+        "title": "Google Consent Mode",
         "type": "string"
       }
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
   "vendor": "vtex",
-  "version": "2.0.8",
+  "version": "2.0.7",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
-  "vendor": "arcaplanetqa",
-  "version": "0.0.1",
+  "vendor": "vtex",
+  "version": "2.0.8",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
   "vendor": "arcaplanetqa",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {
@@ -35,7 +35,16 @@
       },
       "gcm": {
         "title": "Google Consent Mode",
-        "type": "string"
+        "type": "string",
+        "default": "enabled",
+        "enum": [
+          "enabled",
+          "disabled"
+        ],
+        "enumNames": [
+          "enabled",
+          "disabled"
+        ]
       }
     }
   },

--- a/pixel/head-start.html
+++ b/pixel/head-start.html
@@ -1,1 +1,1 @@
-<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="{{settings.cbid}}" type="text/javascript" async></script>
+<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="{{settings.cbid}}" type="text/javascript" data-consentmode="{{settings.gcm}}" async></script>

--- a/react/package.json
+++ b/react/package.json
@@ -22,7 +22,7 @@
     "prettier": "^1.18.2",
     "react-intl": "^3.11.0",
     "tslint-eslint-rules": "^5.4.0",
-    "typescript": "3.8.3"
+    "typescript": "3.9.7"
   },
   "version": "2.0.7"
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5344,7 +5344,12 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.8.3, typescript@^3.7.3:
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+typescript@^3.7.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
#### What problem is this solving?

Cookiebot allows toggling Google Consent Mode on and off as detailed [here](https://support.cookiebot.com/hc/en-us/articles/4417367208594-Disabling-Google-Consent-mode). 

I've added a setting in admin that allow to disable it.

The default behavior for Cookiebot is to have GCM enabled, so I've setted the admin default setting to enabled. 

#### How should this be manually tested?

[Workspace](https://cookiebot--arcaplanetqa.myvtex.com)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
