### PR TITLE
Add default consent and CDN region (com/eu) configurable settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [2.1.0] - 2024-11-08
+### Added
 - Admin settings that enable and configure default consent for cookies
 - Admin setting that switches Cookiebot CDN between .com and .eu [Cookiebot European CDN solution](https://support.cookiebot.com/hc/en-us/articles/4530208762396-Cookiebot-CMP-European-CDN-solution)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-11-08
+- Admin settings that enable and configure default consent for cookies
+- Admin setting that switches Cookiebot CDN between .com and .eu [Cookiebot European CDN solution](https://support.cookiebot.com/hc/en-us/articles/4530208762396-Cookiebot-CMP-European-CDN-solution)
+
 ## [2.0.8] - 2022-08-18
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
   "vendor": "vtex",
-  "version": "2.1.0",
+  "version": "2.0.8",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cookiebot",
   "vendor": "vtex",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "title": "Cookiebot",
   "description": "With a few clicks configure and preview your own cookie declaration and consent dialog.",
   "billingOptions": {
@@ -11,9 +11,7 @@
     },
     "free": true,
     "type": "free",
-    "availableCountries": [
-      "*"
-    ]
+    "availableCountries": ["*"]
   },
   "builders": {
     "pixel": "0.x",
@@ -36,15 +34,70 @@
       "gcm": {
         "title": "Google Consent Mode",
         "type": "string",
-        "default": "enabled",
-        "enum": [
-          "enabled",
-          "disabled"
-        ],
-        "enumNames": [
-          "enabled",
-          "disabled"
-        ]
+        "enum": ["enabled", "disabled"],
+        "default": "enabled"
+      },
+      "cbm": {
+        "title": "Cookie blocking mode",
+        "description": "Choose between automatic or manual cookie blocking. !!! WARNING !!! Automatic cookie blocking may break your store. Use with caution!",
+        "type": "string",
+        "enum": ["auto", "manual"],
+        "default": "manual"
+      },
+      "cdn": {
+        "title": "CDN Region",
+        "description": "Choose the region where the Cookiebot script is hosted. Mind that changing the default region .com may affect functionality if you also employ CSP. Make sure to update your CSP policy accordingly (permit *.cookiebot.eu or *.cookiebot.com).",
+        "type": "string",
+        "enum": ["com", "eu"],
+        "default": "com"
+      },
+      "edc": {
+        "title": "Enable Default Consent",
+        "description": "Enable or disable the default consent mode, activating the options below",
+        "type": "boolean",
+        "default": false
+      },
+      "defaultConsent": {
+        "title": "Default Consent",
+        "type": "object",
+        "properties": {
+          "ad_storage": {
+            "title": "ad_storage",
+            "description": "Sets consent for storing and processing personal data for advertising purposes",
+            "type": "boolean",
+            "default": false
+          },
+          "analytics_storage": {
+            "title": "analytics_storage",
+            "description": "Sets consent for storing and processing personal data for analytics purposes",
+            "type": "boolean",
+            "default": false
+          },
+          "ad_user_data": {
+            "title": "ad_user_data",
+            "description": "Sets consent for sending user data related to advertising to Google",
+            "type": "boolean",
+            "default": false
+          },
+          "ad_personalization": {
+            "title": "ad_personalization",
+            "description": "Sets consent for personalized advertising",
+            "type": "boolean",
+            "default": false
+          },
+          "functionality_storage": {
+            "title": "functionality_storage",
+            "description": "Sets consent for storing and processing personal data for functionality purposes",
+            "type": "boolean",
+            "default": false
+          },
+          "personalization_storage": {
+            "title": "personalization_storage",
+            "description": "Sets consent for storing and processing personal data for personalization purposes",
+            "type": "boolean",
+            "default": false
+          }
+        }
       }
     }
   },

--- a/pixel/body.html
+++ b/pixel/body.html
@@ -1,1 +1,1 @@
-<script>window.__cookiebot_id = "{{settings.cbid}}"</script>
+<script>window.__cookiebot_id = "{{settings.cbid}}"; window.__cookiebot_cdn = "{{settings.cdn}}" || "com"</script>

--- a/pixel/head-start.html
+++ b/pixel/head-start.html
@@ -1,1 +1,34 @@
-<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="{{settings.cbid}}" type="text/javascript" data-consentmode="{{settings.gcm}}" async></script>
+<!-- Google Consent - Default -->
+<script data-cookieconsent="ignore">
+  (function () {
+    if ('{{settings.edc}}' !== 'true') { return }
+    window.dataLayer = window.dataLayer || [];
+
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+
+    function dg(v) {
+      return v === true ? 'granted' : 'denied';
+    }
+
+    try {
+      const dc = JSON.parse(decodeURIComponent('{{settings.defaultConsent}}'));
+      gtag("consent", "default", {
+        ad_personalization: dg(dc.ad_personalization),
+        ad_storage: dg(dc.ad_storage),
+        ad_user_data: dg(dc.ad_user_data),
+        analytics_storage: dg(dc.analytics_storage),
+        functionality_storage: dg(dc.functionality_storage),
+        personalization_storage: dg(dc.personalization_storage),
+        security_storage: "granted",
+        wait_for_update: 500,
+      });
+    } catch (e) {
+      console.info(`\n%c⚠️ Error ⚠️%c \n Cookiebot application not configured.`, 'color: red; font-size: 16px;', 'color: white; font-size: 12px;');
+    }
+    gtag("set", "ads_data_redaction", true);
+    gtag("set", "url_passthrough", false);
+  })()
+</script>
+<!-- End Google Consent - Default -->

--- a/pixel/head.html
+++ b/pixel/head.html
@@ -1,0 +1,17 @@
+<script>
+  const tag = document.createElement('script');
+  const attr = {
+    type: 'text/javascript',
+    src: 'https://consent.cookiebot.' + ('{{settings.cdn}}' || 'com') + '/uc.js',
+    id: 'Cookiebot',
+    'data-cbid': '{{settings.cbid}}',
+    'data-consentmode': '{{settings.gcm}}' || 'enabled',
+    async: !0
+  }
+  for (const key in attr) {
+    tag.setAttribute(key, attr[key]);
+  }
+
+  const s = document.head.getElementsByTagName('script')[0];
+  s.parentNode.insertBefore(tag, s)
+</script>

--- a/react/CookieDeclaration.tsx
+++ b/react/CookieDeclaration.tsx
@@ -9,11 +9,12 @@ const CookieDeclaration: FC = () => {
       return
     }
     const cbid = window.__cookiebot_id
+    const cdn = window.__cookiebot_cdn
     const script = document.createElement('script')
     script.id = 'CookieDeclaration'
     script.type = 'text/javascript'
     script.async = true
-    script.src = `https://consent.cookiebot.com/${cbid}/cd.js`
+    script.src = `https://consent.cookiebot.${cdn}/${cbid}/cd.js`
     node.appendChild(script)
   }, [])
 

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -1,5 +1,6 @@
 interface Window extends Window {
   __cookiebot_id: string
+  __cookiebot_cdn: string
   Cookiebot: Cookiebot
 }
 


### PR DESCRIPTION
* Move uc.js loading to head.html to ensure loading after default consent

#### What problem is this solving?

Default consent should be configured prior to loading the consent application

#### How should this be manually tested?

* Install the new version
* Make sure the existing functionality is not broken (default consent is not enabled by default, needs to be marked true in the settings app)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [ ] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
